### PR TITLE
Change directory exclusions as well as directory checking to use uppe…

### DIFF
--- a/VMSBuildSync/RemoteSync.cs
+++ b/VMSBuildSync/RemoteSync.cs
@@ -115,6 +115,13 @@ namespace VMSBuildSync
                             excl.ftypes[ix] = excl.ftypes[ix].ToLower();
                         }
                     }
+                    if (excl.directories.Count<string>() > 0)
+                    {
+                        for (int ix = 0; ix < excl.directories.Count<string>() - 1; ix++)
+                        {
+                            excl.directories[ix] = excl.directories[ix].ToUpper();
+                        }
+                    }
                     Logger.WriteLine(10, $"file and folder exclusions loaded from exclusions.json");
                 }
                 catch
@@ -505,6 +512,7 @@ namespace VMSBuildSync
                 try
                 {
                     var directoryName = item.Split(Path.DirectorySeparatorChar).Last();
+                    directoryName = directoryName.ToUpper();
                     if (!directoryName.Contains("."))
                     {
 

--- a/VMSBuildSync/RemoteSync.cs
+++ b/VMSBuildSync/RemoteSync.cs
@@ -101,11 +101,19 @@ namespace VMSBuildSync
             });
 
             //If we have an exclusions.json file, load it
+            //get the application folder
+            string assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            Logger.WriteLine(5, "Application is running from " + assemblyPath);
             if (File.Exists("exclusions.json"))
+			{
+                assemblyPath = ".";
+			}
+            Logger.WriteLine(5, "Checking for exclusions in " + assemblyPath);
+            if (File.Exists(assemblyPath + "\\exclusions.json"))
             {
                 try
                 {
-                    string readExclusions = File.ReadAllText(@"exclusions.json"); //both windows (alt) and linux use / as separator
+                    string readExclusions = File.ReadAllText(assemblyPath + "\\exclusions.json"); //both windows (alt) and linux use / as separator
                     excl = JsonSerializer.Deserialize<Exclusions>(readExclusions);
                     //Lower case all the file extensions
                     if (excl.ftypes.Count<string>() > 0)
@@ -113,13 +121,6 @@ namespace VMSBuildSync
                         for (int ix = 0; ix < excl.ftypes.Count<string>() - 1; ix++)
                         {
                             excl.ftypes[ix] = excl.ftypes[ix].ToLower();
-                        }
-                    }
-                    if (excl.directories.Count<string>() > 0)
-                    {
-                        for (int ix = 0; ix < excl.directories.Count<string>() - 1; ix++)
-                        {
-                            excl.directories[ix] = excl.directories[ix].ToUpper();
                         }
                     }
                     Logger.WriteLine(10, $"file and folder exclusions loaded from exclusions.json");
@@ -512,11 +513,10 @@ namespace VMSBuildSync
                 try
                 {
                     var directoryName = item.Split(Path.DirectorySeparatorChar).Last();
-                    directoryName = directoryName.ToUpper();
                     if (!directoryName.Contains("."))
                     {
 
-                        if (excl != null && excl.directories.Count<string>() > 0 && excl.directories.Contains(directoryName))
+                        if (excl != null && excl.directories.Count<string>() > 0 && excl.directories.Contains(directoryName,StringComparer.OrdinalIgnoreCase))
                             continue;
 
                         if (!remoteDirectories.ContainsKey(directoryName))

--- a/VMSBuildSync/RemoteSync.cs
+++ b/VMSBuildSync/RemoteSync.cs
@@ -105,9 +105,9 @@ namespace VMSBuildSync
             string assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
             Logger.WriteLine(5, "Application is running from " + assemblyPath);
             if (File.Exists("exclusions.json"))
-			{
+            {
                 assemblyPath = ".";
-			}
+            }
             Logger.WriteLine(5, "Checking for exclusions in " + assemblyPath);
             if (File.Exists(assemblyPath + "\\exclusions.json"))
             {


### PR DESCRIPTION
This is the to force directory exclusions to uppercase and directory compares to uppercase since VMS directories will be in upper case.  This seems to eliminate trying to create folders from Windows which are in mixed case and/or lowercase once they've been created on VMS.  

While I'm not 100% sure if this handles the exclusions properly, I believe it does.
